### PR TITLE
Upgrade to .NET 9 and simplify project configuration

### DIFF
--- a/AviDrugZ/AviDrugZ.csproj
+++ b/AviDrugZ/AviDrugZ.csproj
@@ -1,31 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>x64</Platforms>
+	  <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SignAssembly>True</SignAssembly>
     <DelaySign>False</DelaySign>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <ApplicationIcon>Resources\splash.ico</ApplicationIcon>
     <AssemblyVersion>3.1</AssemblyVersion>
     <FileVersion>3.1</FileVersion>
-    <AssemblyOriginatorKeyFile>J:\Git\AviDrugZ\MyKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-
   <ItemGroup>
     <None Remove="Lib\Nyan.wav" />
     <None Remove="Resources\splash.png" />
   </ItemGroup>
-
   <ItemGroup>
     <Content Include="Resources\splash.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.15" />
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
@@ -33,18 +29,15 @@
     <PackageReference Include="WindowsShortcutFactory" Version="1.2.0" />
     <PackageReference Include="WPF-UI" Version="2.0.3" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="VRCApi\" />
   </ItemGroup>
-
   <ItemGroup>
     <Content Include="Resources\Nyan.wav">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Resource Include="Resources\splash.png" />
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Properties\Settings.Designer.cs">
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
@@ -52,16 +45,10 @@
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
   </ItemGroup>
-
   <ItemGroup>
     <None Update="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="if $(ConfigurationName) == Release $(ProjectDir)postbuild.bat $(SolutionDir)Updater\bin\Release\net6.0\publish\win-x64 $(SolutionDir)AviDrugZ\bin\Release\net6.0-windows\publish\win-x64" />
-  </Target>
-
 </Project>


### PR DESCRIPTION
- Updated target framework from `net6.0-windows` to `net9.0-windows`.
- Changed `Platforms` property to target only `x64`.
- Added `RuntimeIdentifier` for `win-x64`.
- Removed `AssemblyOriginatorKeyFile`, indicating a change in signing.
- Eliminated the `PostBuild` target for deployment.